### PR TITLE
Update: dockerビルドにてpacmanのdb/pkg共有機能を実装

### DIFF
--- a/tools/docker-build.sh
+++ b/tools/docker-build.sh
@@ -26,8 +26,7 @@ _usage () {
 }
 
 # Start define var
-[[ -d /var/cache/pacman/pkg ]] && SHARE_PKG_DIR='/var/cache/pacman/pkg' || SHARE_PKG_DIR=${script_path}/cache/pkg
-[[ -d /var/lib/pacman ]] && SHARE_DB_DIR='/var/lib/pacman/sync' || SHARE_DB_DIR=${script_path}/cache/sync
+[[ -d /var/cache/pacman/pkg ]] && [[ -d /var/lib/pacman/sync ]] && SHARE_PKG_DIR='/var/cache/pacman/pkg' && SHARE_DB_DIR='/var/lib/pacman/sync' || SHARE_PKG_DIR=${script_path}/cache/pkg && SHARE_DB_DIR=${script_path}/cache/sync
 # End define var
 
 
@@ -48,7 +47,7 @@ while (( $# > 0 )); do
             shift 1
             ;;
         -p | --pkg-cache-dir)
-            [[ -d ${2} ]] && mkdir -p ${2}/pkg && mkdir -p ${2}/sync && SHARE_PKG_DIR=${2}/pkg && SHARE_DB_DIR=${2}/sync || echo "Error: The directory is not found or cannot make directory." 1>&2
+            [[ -d ${2} ]] && mkdir -p ${2}/pkg && mkdir -p ${2}/sync && SHARE_PKG_DIR=${2}/pkg && SHARE_DB_DIR=${2}/sync || echo "Error: The directory is not found or cannot make directory." 1>&2 && exit 1
             ;;
         -h | --help)
             _usage

--- a/tools/docker-build.sh
+++ b/tools/docker-build.sh
@@ -11,15 +11,25 @@ if ! type docker >/dev/null 2>&1; then
     exit 1
 fi
 
+script_path="$( cd -P "$( dirname "$(readlink -f "$0")" )" && pwd )/.."
+
 _usage () {
     echo "usage ${0} [options]"
     echo
     echo " General options:"
-    echo "    -o | --build-opiton \"[options]\"     send the build option to build.sh"
+    echo "    -o | --build-opiton \"[options]\"     Send the build option to build.sh"
     echo "    -c | --clean                          Enable --no-cache option when build docker image"
+    echo "    -s | --no-share-pkgfile               Disable pacman pkgcache"
+    echo "    -p | --pkg-cache-dir \"[path]\"       Select pacman pkg cache directory"
     echo "    -h | --help                           This help message and exit"
     echo
 }
+
+# Start define var
+[[ -d /var/cache/pacman/pkg ]] && SHARE_PKG_DIR='/var/cache/pacman/pkg' || SHARE_PKG_DIR=${script_path}/cache/pkg
+[[ -d /var/lib/pacman ]] && SHARE_DB_DIR='/var/lib/pacman/sync' || SHARE_DB_DIR=${script_path}/cache/sync
+# End define var
+
 
 # Start parse options
 ARGUMENT="${@}"
@@ -32,6 +42,13 @@ while (( $# > 0 )); do
         -c | --clean)
             NO_CACHE="--no-cache" # Enable --no-cache option
             shift 1
+            ;;
+        -s | --no-share-pkgfile)
+            NO_SHARE_PKG=True
+            shift 1
+            ;;
+        -p | --pkg-cache-dir)
+            [[ -d ${2} ]] && mkdir -p ${2}/pkg && mkdir -p ${2}/sync && SHARE_PKG_DIR=${2}/pkg && SHARE_DB_DIR=${2}/sync || echo "Error: The directory is not found or cannot make directory." 1>&2
             ;;
         -h | --help)
             _usage
@@ -49,7 +66,7 @@ while (( $# > 0 )); do
 done
 # End parse options
 
-script_path="$( cd -P "$( dirname "$(readlink -f "$0")" )" && pwd )/.."
 cd $script_path
 docker build ${NO_CACHE} -t alterlinux-build:latest .
-docker run -e _DOCKER=true -t -i --privileged -v $script_path/out:/alterlinux/out -v /usr/lib/modules:/usr/lib/modules:ro alterlinux-build "${BUILD_OPT}"
+[[ "${NO_SHARE_PKG}" == "True" ]] && SHARE_PACMAN_DIR="" || SHARE_PACMAN_DIR="-v ${SHARE_PKG_DIR}:/var/cache/pacman/pkg -v ${SHARE_DB_DIR}:/var/lib/pacman/sync"
+docker run -e _DOCKER=true -t -i --privileged -v $script_path/out:/alterlinux/out -v /usr/lib/modules:/usr/lib/modules:ro ${SHARE_PACMAN_DIR} alterlinux-build "${BUILD_OPT}"


### PR DESCRIPTION
Dockerでビルドする際，ホストに/var/cache/pacman/pkgがあり，かつ/var/lib/pacman/syncがある場合はそれぞれをdockerコンテナに接続
少なくとも一方が存在しない場合は，${script_path}/cache/{pkg, sync}とコンテナを接続する設計にしました。

オプション '-s' でpacmanのキャッシュ共有機能をオフに，オプション '-p [path]' で共有するディレクトリを指定できます。
